### PR TITLE
Support for New Architecture in React Native

### DIFF
--- a/src/components/AnimatedDigit.tsx
+++ b/src/components/AnimatedDigit.tsx
@@ -171,7 +171,7 @@ export const AnimatedDigit: React.FC<AnimatedDigitProps> = ({
                   numberStyle,
                   {
                     position: index === 0 ? "relative" : "absolute",
-                    transform: [{ translateY: height * index }],
+                    top: height * index,
                   },
                 ]}
                 {...textProps}
@@ -190,7 +190,7 @@ export const AnimatedDigit: React.FC<AnimatedDigitProps> = ({
                   {
                     paddingHorizontal: index === 0 ? resolvedPadding : 0,
                     position: index === 0 ? "relative" : "absolute",
-                    transform: [{ translateY: height * index }],
+                    top: height * index,
                   },
                 ]}
                 {...textProps}


### PR DESCRIPTION
This pull request addresses an issue in the new React Native architecture where transform: [{ translateY: height * index }] is not handled correctly during rendering. The issue caused all Text components to be positioned at layout.y = 0, resulting in overlapping elements.

To fix this, the style has been updated to use the top property instead of translateY, ensuring the correct vertical positioning of each element ( Fixes #10 ).