### PR TITLE
Fix: Reanimated ReferenceError

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
   "author": "Bouarour Mohammed",
   "license": "MIT",
   "description": "🚀 The Animated Digits component for React Native seamlessly blends a sophisticated number rotation effect with dynamic value updates, creating an engaging and interactive experience that enhances your user interfaces with a touch of elegance and excitement.",
-  "dependencies": {
-    "react-native-reanimated": "^3.15.1"
-  },
   "devDependencies": {
     "@types/react": "^18.3.5",
     "@types/react-native": "^0.73.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-animated-rolling-numbers",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "main": "src/index.ts",
   "scripts": {
     "build": "tsc"


### PR DESCRIPTION
## Summary

This pull request removes `react-native-reanimated` from the `dependencies` section of `package.json` and promotes it to a `peerDependency`. This change aims to improve the overall developer experience and prevent potential conflicts related to `react-native-reanimated` versioning (Issue #9).

## Motivation

Including `react-native-reanimated` as a direct dependency can lead to issues in projects that already have `react-native-reanimated` installed:

*   **Duplicate Installations:**  The package could install its own version of `react-native-reanimated`, even if the parent project already has it. This can lead to increased bundle sizes and potential version conflicts.
*   **Versioning Conflicts:**  If the version range specified in `dependencies` conflicts with the version in the parent project, it can cause unexpected behavior or runtime errors.

By making `react-native-reanimated` a `peerDependency`, we ensure that the responsibility of installing and managing the `react-native-reanimated` version is delegated to the consuming project. This also allows consumers to update to newer versions of `react-native-reanimated` independently of this library.

## Changes

*   Removed `"react-native-reanimated": "^3.15.1"` from the `dependencies` section of `package.json`.
*   Kept `"react-native-reanimated": ">=2.0.0"` in the `peerDependencies` section of `package.json`.

## Impact

**Breaking Change:** This change is considered a breaking change because projects that use this library will now need to explicitly install `react-native-reanimated` as a dependency.

**Users should:**

1.  Ensure they have `react-native-reanimated` installed in their project (`npm install react-native-reanimated` or `yarn add react-native-reanimated`).
2.  Verify that the installed version of `react-native-reanimated` is >= 2.0.0.

**Documentation:**

*   The README has been updated to reflect this change and provide clear installation instructions.