### PR TITLE
fix: space separator fix

### DIFF
--- a/src/components/AnimatedDigit.tsx
+++ b/src/components/AnimatedDigit.tsx
@@ -103,7 +103,7 @@ export const AnimatedDigit: React.FC<AnimatedDigitProps> = ({
   numberTextProps,
   ...rest
 }) => {
-  const isNumeric = !isNaN(Number(value));
+  const isNumeric = value.trim() !== '' && !isNaN(Number(value));
   const animatedValue = useSharedValue(isNumeric ? Number(value) : 0);
   const animatedStyle = useAnimatedStyle(
     () => ({


### PR DESCRIPTION
Currently if the grouping used is a space character this is replaced with a 0 since technically " " is numeric.