### PR TITLE
lint: avoid type error in strict typescript projects

### DIFF
--- a/src/components/AnimatedDigit.tsx
+++ b/src/components/AnimatedDigit.tsx
@@ -35,17 +35,17 @@ export interface AnimatedDigitProps
   /** Style for the container wrapping the animated text. */
   containerStyle?: StyleProp<ViewStyle>;
   /** Props for the primary text component used in the component. */
-  textProps?: Omit<React.ComponentProps<typeof Text>, "style">;
+  textProps?: Omit<React.ComponentProps<typeof Text>, "style"> | undefined;
   /** Props for the number text components. */
-  numberTextProps?: Omit<React.ComponentProps<typeof Text>, "style">;
+  numberTextProps?: Omit<React.ComponentProps<typeof Text>, "style"> | undefined;
   /** Props for the comma text component, if used. */
-  commaTextProps?: Omit<React.ComponentProps<typeof Text>, "style">;
+  commaTextProps?: Omit<React.ComponentProps<typeof Text>, "style"> | undefined;
   /** Props for the dot (decimal point) text component, if used. */
-  dotTextProps?: Omit<React.ComponentProps<typeof Text>, "style">;
+  dotTextProps?: Omit<React.ComponentProps<typeof Text>, "style"> | undefined;
   /** Props for the compact notation text components (K, M, B, T). */
-  compactNotationTextProps?: Omit<React.ComponentProps<typeof Text>, "style">;
+  compactNotationTextProps?: Omit<React.ComponentProps<typeof Text>, "style"> | undefined;
   /** Props for the sign text component, if used. */
-  signTextProps?: Omit<React.ComponentProps<typeof Text>, "style">;
+  signTextProps?: Omit<React.ComponentProps<typeof Text>, "style"> | undefined;
   /** Style for the primary text component. */
   textStyle?: StyleProp<TextStyle>;
   /** Style for the number text components. */
@@ -63,11 +63,11 @@ export interface AnimatedDigitProps
     duration?: number;
     reduceMotion?: ReduceMotion;
     easing?: EasingFunction | EasingFunctionFactory;
-  };
+  } | undefined;
   /** Callback function invoked when the animation completes. */
-  animationCallback?: AnimationCallback;
+  animationCallback?: AnimationCallback | undefined;
   /** Custom function to animate the value change. Defaults to a bounce animation. */
-  animateToNewValue?: (newValue: number, variant?: DigitVariant) => number;
+  animateToNewValue?: ((newValue: number, variant?: DigitVariant) => number) | undefined;
 }
 
 /**


### PR DESCRIPTION
### What?

This PR updates the types to make typescript happy in projects that use [`exactOptionalPropertyTypes: true`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes).

### Why?

If a strict typescript project imports `react-native-animated-rolling-numbers` package, typechecking will fail (in the consuming package) with the following error:

```
../../node_modules/react-native-animated-rolling-numbers/src/components/AnimatedRollingNumber.tsx:180:12 - error TS2375: Type '{ key: number; value: string; height: number; containerStyle: StyleProp<ViewStyle>; textStyle: StyleProp<TextStyle>; numberTextProps: Omit<...> | undefined; ... 11 more ...; animateToNewValue: ((newValue: number, variant?: DigitVariant | undefined) => number) | undefined; }' is not assignable to type 'AnimatedDigitProps' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  Types of property 'numberTextProps' are incompatible.
    Type 'Omit<TextProps, "style"> | undefined' is not assignable to type 'Omit<TextProps, "style">'.
      Type 'undefined' is not assignable to type 'Omit<TextProps, "style">'.

180           <AnimatedDigit
               ~~~~~~~~~~~~~


Found 1 error in ../../node_modules/react-native-animated-rolling-numbers/src/components/AnimatedRollingNumber.tsx:180
```

### Repro

1. Clone this repo
2. Update tsconfig.json with more strict options
   ```json
	"compilerOptions": {
		"exactOptionalPropertyTypes": true,
		"strictNullChecks": true,
		}
	 ```
3. Run the typechecker `yarn tsc --noEmit`
4. Observe the error:
	```
	src/components/AnimatedRollingNumber.tsx:180:12 - error TS2375: Type '{ key: number; value: string; height: number; containerStyle: StyleProp<ViewStyle>; textStyle: StyleProp<TextStyle>; textProps: Omit<TextProps, "style"> | undefined; ... 12 more ...; animateToNewValue: ((newValue: number, variant?: DigitVariant | undefined) => number) | undefined; }' is not assignable to type 'AnimatedDigitProps' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
		Types of property 'animateToNewValue' are incompatible.
			Type '((newValue: number, variant?: DigitVariant | undefined) => number) | undefined' is not assignable to type '(newValue: number, variant?: DigitVariant | undefined) => number'.
				Type 'undefined' is not assignable to type '(newValue: number, variant?: DigitVariant | undefined) => number'.

	180           <AnimatedDigit
								~~~~~~~~~~~~~


	Found 1 error in src/components/AnimatedRollingNumber.tsx:180
	```
