### PR TITLE
[fix]: typescript errors

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "es2015"],
+    "lib": ["dom", "esnext"],
     "allowJs": true,
     "jsx": "react",
     "declaration": true,


### PR DESCRIPTION
This fixes the following typescript errors

1. Namespace Intl has no exported member LocalesArgument
2. Property 'includes' does not exist on type string[]

These are included in the later version of ECMAScript